### PR TITLE
feat: add type 3 for common documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Supported Platforms:
 	/**
 	 * Displays native prompt for user to select files.
 	 *
-	 * @param type (eg. 1 for images only and 2 for all type of files).
+	 * @param type (eg. 1 for images only, 2 for all type of files, 3 for images/videos/pdf/offices documents).
 	 *
 	 * @returns Promise containing selected file's data,
 	 * URI, MIME type and name.

--- a/src/android/MultipleDocumentsPicker.java
+++ b/src/android/MultipleDocumentsPicker.java
@@ -58,6 +58,10 @@ public class MultipleDocumentsPicker extends CordovaPlugin {
        Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
        if(type == 1) {
         intent.setType("image/*");
+       } else if(type == 3) {
+           intent.setType("*/*");
+           String[] mimeTypes = {"application/pdf", "image/*", "video/*", "application/msword", "application/vnd.ms.excel", "application/vnd.ms-powerpoint", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "application/vnd.openxmlformats-officedocument.presentationml.presentation"};
+           intent.putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes);
        } else {
         intent.setType("*/*");
        }

--- a/src/ios/MultipleDocumentsPicker.swift
+++ b/src/ios/MultipleDocumentsPicker.swift
@@ -8,6 +8,8 @@ import Foundation
         var types = [String]()
         if(type == 1){
             types = ["public.image"]
+        } else if(type == 3){
+            types = ["public.image", "public.movie", "com.adobe.pdf", "com.microsoft.word.doc", "com.microsoft.excel.xls", "com.microsoft.powerpoint.ppt", "org.openxmlformats.wordprocessingml.document", "org.openxmlformats.spreadsheetml.sheet", "org.openxmlformats.presentationml.presentation"]
         } else {
             types = ["public.item"]
         }


### PR DESCRIPTION
When we select all documents, it shows too many files like .txt and other internal files, which is not very good for most of the users. So I added a type to select only "common documents". Then it is clearer for the end-users.

What I mean by common documents are:
- images
- videos
- pdf
- ms office documents